### PR TITLE
Avoid underscored function variant

### DIFF
--- a/R/2-2.manipulate.R
+++ b/R/2-2.manipulate.R
@@ -702,7 +702,7 @@ get_group_skeleton <- function(go, Group = "v_class", count = NULL, top_N = 8) {
     .[V(tmp_go)$name, "x"]
   suppressWarnings({
     V(tmp_go)$count <- tmp_v %>%
-      dplyr::group_by_(Group) %>%
+      dplyr::group_by(dplyr::pick(dplyr::all_of(Group))) %>%
       dplyr::count() %>%
       tibble::column_to_rownames(Group) %>%
       .[V(tmp_go)$name, "n"]


### PR DESCRIPTION
Hi there, we are working on the next version of dplyr and your package was flagged in our reverse dependency checks.

Your package uses one of the "underscored" versions of a dplyr verb, such as `mutate_()` rather than `mutate()`. These were deprecated in 2017, and are now defunct and must be removed.

dplyr will be released on January 31, 2026. If you could please send an update of your package to CRAN before then, that would help us out a lot! Thanks!